### PR TITLE
Remote-access Feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,23 @@ Usable by: Bot Operator, Server Owner or Bot Owner.
 
 Lists the status of the chat listener for the server.
 
-### `[help, halp, h]`
+### `[remote, rem]`
+
+`!remote <server id> <command> <command args>`
+
+Usable by: Bot Owner.
+
+Allows remote execution of commands on deployed servers by the bot owner,  for checking on bot status and assisting with setup.
+
+### `[servers, sv, guilds]`
+
+`!remote <server id> <command> <command args>`
+
+Usable by: Bot Owner.
+
+Allows remote execution of commands on deployed servers by the bot owner,  for checking on bot status and assisting with setup.
+
+### `[help, h]`
 
 `!help`
 

--- a/readme.md
+++ b/readme.md
@@ -125,11 +125,11 @@ Allows remote execution of commands on deployed servers by the bot owner,  for c
 
 ### `[servers, sv, guilds]`
 
-`!remote <server id> <command> <command args>`
+`!servers`
 
 Usable by: Bot Owner.
 
-Allows remote execution of commands on deployed servers by the bot owner,  for checking on bot status and assisting with setup.
+Lists all servers that the bot is currently connected to.
 
 ### `[help, h]`
 

--- a/src/adapters/discord/discord.client.js
+++ b/src/adapters/discord/discord.client.js
@@ -10,15 +10,9 @@ async function initialize(onLogin, onException, appConfig){
 
     client.on('ready', () => {
         console.log(`Logged in as ${client.user.tag}!`);
-        for(let guild of client.guilds.cache.array()){
-            if(guild && guild.me){
-                guild.me.setNickname('little-daiko 🔴');
-            }
-            console.log(`${guild.name} | ${guild.id}`);
-        }
-        onLogin();
+        onLogin(client);
     });
-
+    console.log(`Client created, awaiting login...`);
     return new DiscordClient(client);
 }
 
@@ -34,6 +28,7 @@ class DiscordClient{
     
     shutdown(){
         if(this.client){
+            console.log(`Client shutting down...`)
             this.client.destroy();
         }
     }

--- a/src/adapters/mildom/mildom.client.js
+++ b/src/adapters/mildom/mildom.client.js
@@ -1,7 +1,6 @@
 const { v4 } = require('uuid');
 const https = require('https');
 const WebSocket = require('ws');
-const { throws } = require('assert');
 
 const liveInfoURL = "https://cloudac.mildom.com/nonolive/gappserv/live/enterstudio"
 const serverUrl = "https://im.mildom.com/"

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,6 +1,14 @@
 async function initialize(appConfig){
     const client = await appConfig.DISCORD_CLIENT.initialize(
-        () => { console.log(`:^)`) }, 
+        (c) => { 
+            for(let guild of c.guilds.cache.array()){
+                if(guild && guild.me){
+                    guild.me.setNickname('little-daiko 🔴');
+                    // TODO: notify servers of changes since last login
+                }
+                console.log(`${guild.name} | ${guild.id}`);
+            } 
+        }, 
         (input, e) => {
             console.error(e);
             const error = `Sorry! We hit an error! The stupid mother fucker who wrote this bot doesn't know how to fucking program: \`\`\`${e}\`\`\``

--- a/src/bot.js
+++ b/src/bot.js
@@ -2,6 +2,7 @@ async function initialize(appConfig){
     const client = await appConfig.DISCORD_CLIENT.initialize(
         () => { console.log(`:^)`) }, 
         (input, e) => {
+            console.error(e);
             const error = `Sorry! We hit an error! The stupid mother fucker who wrote this bot doesn't know how to fucking program: \`\`\`${e}\`\`\``
             client.respondToMessage(input, error);
         },
@@ -25,7 +26,6 @@ class Bot{
     async shutdown(){
         if(this.client){
             this.client.shutdown();
-            // TODO: clean up mildom listener if one is active
         }
     }
 }

--- a/src/models/command.js
+++ b/src/models/command.js
@@ -12,8 +12,9 @@ function commands(appConfig){
         {
             aliases: ['config', 'conf', 'c'],
             permissions: 1,
-            callback: async (message, args) => { 
-                const fields = appConfig.CONFIG_STORAGE.getAllProperties(message).map(prop => {
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
+                const fields = appConfig.CONFIG_STORAGE.getAllProperties(configKey).map(prop => {
                     return {
                         name: `${prop[0]}:`,
                         value: `\`${JSON.stringify(prop[1], undefined, 2)}\``,
@@ -35,11 +36,12 @@ function commands(appConfig){
         {
             aliases: ['prefix', 'p'],
             permissions: 2,
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 if(args && args.length > 0){
-                        appConfig.CONFIG_STORAGE.setProperty(message, "prefix", args[0]);
-                        return REACT_OK;
-                    }
+                    appConfig.CONFIG_STORAGE.setProperty(configKey, "prefix", args[0]);
+                    return REACT_OK;
+                }
                 return REACT_ERROR;
             },
             help: 
@@ -53,18 +55,19 @@ function commands(appConfig){
         {
             aliases: ['role', 'r'],
             permissions: 3,
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 if(args && args.length > 1){
                     const type = args[0];
-                    const roles =  appConfig.CONFIG_STORAGE.getProperty(message, "role");
+                    const roles =  appConfig.CONFIG_STORAGE.getProperty(configKey, "role");
                     if(type === 'ops'){
                         roles.ops = args[1];
-                        appConfig.CONFIG_STORAGE.setProperty(message, "role", roles);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "role", roles);
                         return REACT_OK;
                     }
                     if(type === 'alert'){
                         roles.alert = args[1];
-                        appConfig.CONFIG_STORAGE.setProperty(message, "role", roles);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "role", roles);
                         return REACT_OK;
                     }
                 }
@@ -87,11 +90,12 @@ function commands(appConfig){
         {
             aliases: ['streamer', 's'],
             permissions: 2,
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 if(args && args.length > 0){
                     const argId = Number(args[0]);
                     if(!isNaN(argId)){
-                        appConfig.CONFIG_STORAGE.setProperty(message, "streamer", argId);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "streamer", argId);
                         return REACT_OK;
                     }
                 }
@@ -108,10 +112,11 @@ function commands(appConfig){
         {
             aliases: ['users', 'u'],
             permissions: 2,
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 if(args && args.length > 1){
                     const action = args[0];
-                    let users = appConfig.CONFIG_STORAGE.getProperty(message, 'users');
+                    let users = appConfig.CONFIG_STORAGE.getProperty(configKey, 'users');
                     users = users ? users : [];
                     const argIds = [...new Set(args.map((user) => {
                         return Number(user);
@@ -129,11 +134,11 @@ function commands(appConfig){
                             // no users removed
                             return REACT_ERROR;
                         }
-                        appConfig.CONFIG_STORAGE.setProperty(message, "users", updatedUsers);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "users", updatedUsers);
                         return REACT_OK;
                     }else if("add" === action){
                         const updatedUsers = [...new Set(users.concat(argIds))];
-                        appConfig.CONFIG_STORAGE.setProperty(message, "users", updatedUsers);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "users", updatedUsers);
                         return REACT_OK;
                     }
                 }
@@ -157,28 +162,29 @@ function commands(appConfig){
         {
             aliases: ['output', 'out', 'o'],
             permissions: 2,
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 if(args && args.length > 1){
                     const type = args[0];
-                    const channels = appConfig.CONFIG_STORAGE.getProperty(message, "output");
+                    const channels = appConfig.CONFIG_STORAGE.getProperty(configKey, "output");
                     if(type === 'chat'){
                         if(args.length > 2){
                             const operation = args[1];
                             const language = args[2].toLowerCase();
                             if(operation === 'add' && args.length > 3){
                                 channels.chat[language] = args[3];
-                                appConfig.CONFIG_STORAGE.setProperty(message, "output", channels);
+                                appConfig.CONFIG_STORAGE.setProperty(configKey, "output", channels);
                                 return REACT_OK;
                             }else if(operation === 'remove'){
                                 delete channels.chat[language];
-                                appConfig.CONFIG_STORAGE.setProperty(message, "output", channels);
+                                appConfig.CONFIG_STORAGE.setProperty(configKey, "output", channels);
                                 return REACT_OK;
                             }
                         }
                     }
                     if(type === 'alert'){
                         channels.alert = args[1];
-                        appConfig.CONFIG_STORAGE.setProperty(message, "output", channels);
+                        appConfig.CONFIG_STORAGE.setProperty(configKey, "output", channels);
                         return REACT_OK;
                     }
                 }
@@ -262,9 +268,10 @@ function commands(appConfig){
         {
             aliases: ['stop', 'x'],
             permissions: 2, 
-            callback: async (message, args) => { 
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
                 await message.channel.send("Stopping listener.");
-                appConfig.LISTENER_STORAGE.deleteListener(message);
+                appConfig.LISTENER_STORAGE.deleteListener(configKey);
             },
             help: 
             [
@@ -279,11 +286,13 @@ function commands(appConfig){
             permissions: 2,
             callback: async (message, args) => { 
                 const listener = appConfig.LISTENER_STORAGE.getListener(message);
-                const isListening = listener && listener.isListening;
-                if(isListening){
-
-                }else{
-
+                const isListening = listener && listener.isListening();
+                if(message.guild && message.guild.me){
+                    if(isListening){
+                        message.guild.me.setNickname('little-daiko 🟢');
+                    }else{
+                        message.guild.me.setNickname('little-daiko 🔴');
+                    }
                 }
                 const status = isListening ? "listening" : "stopped";
                 message.channel.send(`Current status: \`${status}\`.`)
@@ -297,10 +306,35 @@ function commands(appConfig){
             ]
         },
         {
-            aliases: ['help', 'halp', 'h'],
-            permissions: 1,
+            aliases: ['remote', 'rem'],
+            permissions: 100, 
             callback: async (message, args) => { 
-                const prefix = appConfig.CONFIG_STORAGE.getProperty(message, 'prefix');
+                if(args.length > 1){
+                    const command = commands(appConfig).find(c => { return c.aliases.includes(args[1]); });
+                    const override = {
+                        guild: {
+                            id: args[0]
+                        }
+                    }
+                    return await command.callback(message, args.slice(2), override);
+                }
+                return REACT_ERROR;
+            },
+            help: 
+            [
+                {
+                    usage: `remote <server id> <command> <command args>`,
+                    description: oneline`Allows remote execution of commands on deployed servers by the bot owner, 
+                    for checking on bot status and assisting with setup.`
+                },
+            ]
+        },
+        {
+            aliases: ['help', 'h'],
+            permissions: 1,
+            callback: async (message, args, override) => { 
+                const configKey = override ? override : message;
+                const prefix = appConfig.CONFIG_STORAGE.getProperty(configKey, 'prefix');
                 if(args && args.length > 0){
                     for(let entry of commands(appConfig)){
                         if(entry.aliases.includes(args[0])){

--- a/src/models/command.js
+++ b/src/models/command.js
@@ -330,6 +330,29 @@ function commands(appConfig){
             ]
         },
         {
+            aliases: ['servers', 'sv', 'guilds'],
+            permissions: 100, 
+            callback: async (message, args) => { 
+                const guilds = message.guild.me.client.guilds.cache.array().map((guild) => {
+                    return {
+                        name: `${guild.name}`,
+                        value: `\`${guild.id}\``
+                    }
+                });
+                message.channel.send(discordHelpers.generateEmbed({
+                    message: 'Connected Servers:',
+                    fields: guilds
+                }));
+            },
+            help: 
+            [
+                {
+                    usage: `servers`,
+                    description: oneline`Lists all servers that the bot is currently connected to.`
+                },
+            ]
+        },
+        {
             aliases: ['help', 'h'],
             permissions: 1,
             callback: async (message, args, override) => { 

--- a/src/models/command.spec.js
+++ b/src/models/command.spec.js
@@ -27,7 +27,7 @@ describe("Help command tests", () => {
         // execute test
         expect(sent).toBe(false);
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('help')})[0];
+        const help = commands.find(c => { return c.aliases.includes('help')});
         const result = await help.callback(dummyMessage, undefined);
         expect(sent).toBe(true);
         expect(embed.message).toContain('streamer');
@@ -79,7 +79,7 @@ describe("Help command tests", () => {
         // execute test
         expect(sent).toBe(false);
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('help')})[0];
+        const help = commands.find(c => { return c.aliases.includes('help')});
         const result = await help.callback(dummyMessage, 'users');
         expect(sent).toBe(true);
         expect(embed.fields.length).toBe(2);
@@ -116,7 +116,7 @@ describe("Config command tests", () => {
         // execute test
         expect(sent).toBe(false);
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('config')})[0];
+        const help = commands.find(c => { return c.aliases.includes('config')});
         const result = await help.callback(dummyMessage, undefined);
         expect(sent).toBe(true);
         expect(embed.fields.length).toBe(2);
@@ -142,7 +142,7 @@ describe("Role command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('role')})[0];
+        const help = commands.find(c => { return c.aliases.includes('role')});
         const result = await help.callback(dummyMessage, ['admin', 'secondary']);
         expect(role).toEqual(undefined);
         expect(result).toEqual('❌')
@@ -164,7 +164,7 @@ describe("Role command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('role')})[0];
+        const help = commands.find(c => { return c.aliases.includes('role')});
         const result = await help.callback(dummyMessage, ['ops', 'admin']);
         expect(role).toEqual({ops: 'admin'});
         expect(result).toEqual('✔️')
@@ -186,7 +186,7 @@ describe("Role command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('role')})[0];
+        const help = commands.find(c => { return c.aliases.includes('role')});
         const result = await help.callback(dummyMessage, ['alert', 'mildom']);
         expect(role).toEqual({alert: 'mildom'});
         expect(result).toEqual('✔️')
@@ -205,7 +205,7 @@ describe("Role command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('role')})[0];
+        const help = commands.find(c => { return c.aliases.includes('role')});
         const result = await help.callback(dummyMessage, undefined);
         expect(role).toEqual(undefined);
         expect(result).toEqual('❌');
@@ -227,7 +227,7 @@ describe("Streamer command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('streamer')})[0];
+        const help = commands.find(c => { return c.aliases.includes('streamer')});
         const result = await help.callback(dummyMessage, [12345, 'secondary']);
         expect(streamer).toEqual(12345);
         expect(result).toEqual('✔️')
@@ -246,7 +246,7 @@ describe("Streamer command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('streamer')})[0];
+        const help = commands.find(c => { return c.aliases.includes('streamer')});
         const result = await help.callback(dummyMessage, undefined);
         expect(streamer).toEqual(undefined);
         expect(result).toEqual('❌');
@@ -265,7 +265,7 @@ describe("Streamer command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('streamer')})[0];
+        const help = commands.find(c => { return c.aliases.includes('streamer')});
         const result = await help.callback(dummyMessage, ['12a345', 'secondary']);
         expect(streamer).toEqual(undefined);
         expect(result).toEqual('❌');
@@ -290,7 +290,7 @@ describe("Channel command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('output')})[0];
+        const help = commands.find(c => { return c.aliases.includes('output')});
         const result = await help.callback(dummyMessage, ['chat', 'add', 'en', 'general', 'secondary']);
         expect(channel).toEqual({chat: {en: 'general'}});
         expect(result).toEqual('✔️')
@@ -356,7 +356,7 @@ describe("Users command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('users')})[0];
+        const help = commands.find(c => { return c.aliases.includes('users')});
         const result = await help.callback(dummyMessage, ['add', 12345, 'secondary', 67890]);
         expect(users).toEqual([12345, 67890]);
         expect(result).toEqual('✔️')
@@ -378,7 +378,7 @@ describe("Users command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('users')})[0];
+        const help = commands.find(c => { return c.aliases.includes('users')});
         const result = await help.callback(dummyMessage, ['add']);
         expect(users).toEqual([3456, 2313]);
         expect(result).toEqual('❌');
@@ -511,7 +511,7 @@ describe("Start command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('start')})[0];
+        const help = commands.find(c => { return c.aliases.includes('start')});
         await help.callback(dummyMessage, []);
         await new Promise((r) => setTimeout(r, 2000));
         expect(listener).toBeInstanceOf(AppConfig.MILDOM_CLIENT.ChatListener);
@@ -543,9 +543,122 @@ describe("Stop command tests", () => {
         }
         // execute test
         const commands = AppConfig.COMMANDS(dummyConfig);
-        const help = commands.filter(c => { return c.aliases.includes('stop')})[0];
+        const help = commands.find(c => { return c.aliases.includes('stop')});
         await help.callback(dummyMessage, []);
         expect(sent).toBe(true);
         expect(deleted).toBe(true);
+    });
+});
+
+describe("Remote command tests", () => {
+    test("Remote set prefix", async() => {
+        // set up mock dependencies
+        let newProp = undefined;
+        const dummyConfig = {
+            CONFIG_STORAGE:{
+                getProperty(){
+                    return '!'
+                },
+                setProperty(key, prop, input){
+                    newProp = input;
+                }
+            },
+            COMMANDS: AppConfig.COMMANDS,
+            PERMISSIONS: AppConfig.PERMISSIONS,
+            DISCORD_HELPERS: {
+                generateEmbed(input){
+                    return input;
+                }
+            },
+        }
+        let sent = false;
+        const dummyMessage = {
+            channel: {
+                send(){
+                    sent = true;
+                }
+            },
+        }
+        // execute test
+        const commands = AppConfig.COMMANDS(dummyConfig);
+        const remote = commands.find(c => { return c.aliases.includes('remote')});
+        const result = await remote.callback(dummyMessage, ['11223344', 'prefix', '?']);
+        expect(newProp).toBe('?');
+        expect(result).toBe('✔️');
+    });
+});
+
+describe("Status command tests", () => {
+    test("Status up", async() => {
+        // set up mock dependencies
+        const dummyConfig = {
+            LISTENER_STORAGE: {
+                getListener(){
+                    return {
+                        isListening(){
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        let sent = false;
+        let nickname = undefined;
+        const dummyMessage = {
+            channel: {
+                send(){
+                    sent = true;
+                }
+            },
+            guild:{
+                me:{
+                    setNickname(nick){
+                        nickname = nick;
+                    }
+                }
+            }
+        }
+        // execute test
+        const commands = AppConfig.COMMANDS(dummyConfig);
+        const status = commands.find(c => { return c.aliases.includes('status')});
+        const result = await status.callback(dummyMessage, []);
+        expect(sent).toBe(true);
+        expect(nickname).toBe('little-daiko 🟢');
+    });
+    test("Status down", async() => {
+        // set up mock dependencies
+        const dummyConfig = {
+            LISTENER_STORAGE: {
+                getListener(){
+                    return {
+                        isListening(){
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        let sent = false;
+        let nickname = undefined;
+        const dummyMessage = {
+            channel: {
+                send(){
+                    sent = true;
+                }
+            },
+            guild:{
+                me:{
+                    setNickname(nick){
+                        nickname = nick;
+                    }
+                }
+            }
+        }
+        // execute test
+        const commands = AppConfig.COMMANDS(dummyConfig);
+        const status = commands.find(c => { return c.aliases.includes('status')});
+        const result = await status.callback(dummyMessage, []);
+        expect(sent).toBe(true);
+        expect(nickname).toBe('little-daiko 🔴');
     });
 });


### PR DESCRIPTION
This feature accomplishes:

- Adding a `remote` command so that the bot owner may execute bot commands on connected servers remotely.
- Adding a `servers` command so that the bot owner may list all active servers the bot is on.