### PR TITLE
HOTFIX: Deadlock Listener State

### DIFF
--- a/src/persistence/listener.storage.js
+++ b/src/persistence/listener.storage.js
@@ -35,7 +35,9 @@ function getListener(subject){
 function deleteListener(subject){
     const key = AppConfig.DISCORD_HELPERS.getGuildId(subject);
     if(storage.has(key)){
-        storage.get(key).stopListener();
+        if(storage.get(key)){
+            storage.get(key).stopListener();
+        }
         storage.delete(key);
     }
     return key;


### PR DESCRIPTION
This pull request fixes:

- Case where Listener Storage would get an `undefined` reference stored, and then be unable to be rebooted because the cleanup method was being called on said undefined reference.